### PR TITLE
Set MySQL admin password

### DIFF
--- a/roles/preconf/tasks/db.yml
+++ b/roles/preconf/tasks/db.yml
@@ -16,6 +16,9 @@
               name={{mysql_user_name}} password={{mysql_user_psw}} state=present
               priv=zotero_master.*:SELECT,INSERT,UPDATE,DELETE/zotero_shards.*:SELECT,INSERT,UPDATE,DELETE/zotero_ids.*:SELECT,INSERT,DELETE/zotero_www.*:SELECT,INSERT,DELETE
 
+- name: set password for mysql admin user
+  mysql_user: check_implicit_admin=yes login_user={{mysql_adm_user}} login_password={{mysql_adm_psw}}
+              name={{mysql_adm_user}} password={{mysql_adm_psw}} state=present
 
 - name: drop DBs
   mysql_db: login_user={{mysql_adm_user}} login_password={{mysql_adm_psw}} name=zotero_{{item}} state=absent


### PR DESCRIPTION
I'm using Ubuntu Trusty.
When I ran the playbook, I got this error.
TASK: [preconf | restart mysql] **********************************************\* 
changed: [default] => {"changed": true, "name": "mysql", "state": "started"}

TASK: [preconf | delete mysql user] ******************************************\* 
ok: [default] => {"changed": false, "user": "zotero"}

TASK: [preconf | create mysql user with defined priveleges] ******************\* 
changed: [default] => {"changed": true, "user": "zotero"}

TASK: [preconf | drop DBs] ***************************************************\* 
failed: [default] => (item=master) => {"failed": true, "item": "master"}
msg: unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials
failed: [default] => (item=shards) => {"failed": true, "item": "shards"}
msg: unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials
failed: [default] => (item=ids) => {"failed": true, "item": "ids"}
msg: unable to connect, check login_user and login_password are correct, or alternatively check ~/.my.cnf contains credentials

FATAL: all hosts have already failed -- aborting
